### PR TITLE
Fixed catch.hpp include path to support catch version > 2.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 *.#*
 *.o
 *.so
-
+build
+test/*.pgm
+test/*.ppm

--- a/test/enum_helper_test.cpp
+++ b/test/enum_helper_test.cpp
@@ -1,6 +1,6 @@
 
 // catch
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 // std
 #include <sstream>

--- a/test/image_algos_test.cpp
+++ b/test/image_algos_test.cpp
@@ -1,6 +1,6 @@
 
 // catch
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 // std
 #include <thread>

--- a/test/image_expression_test.cpp
+++ b/test/image_expression_test.cpp
@@ -1,6 +1,6 @@
 
 // catch
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 // std
 #include <sstream>

--- a/test/image_loader_test.cpp
+++ b/test/image_loader_test.cpp
@@ -1,6 +1,6 @@
 
 // catch
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 // std
 #include <cstdlib>

--- a/test/image_stats_test.cpp
+++ b/test/image_stats_test.cpp
@@ -1,6 +1,6 @@
 
 // catch
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 // local
 #include "test_utils.h"

--- a/test/image_test.cpp
+++ b/test/image_test.cpp
@@ -1,6 +1,6 @@
 
 // catch
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 // std
 #include <fstream>

--- a/test/image_utils_test.cpp
+++ b/test/image_utils_test.cpp
@@ -1,6 +1,6 @@
 
 // catch
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 // std
 #include <fstream>

--- a/test/image_view_test.cpp
+++ b/test/image_view_test.cpp
@@ -1,6 +1,6 @@
 
 // catch
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 // std
 #include <sstream>

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,7 +1,7 @@
 
 // catch
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 // leave empty to speed up compiles; see:
 // https://github.com/catchorg/Catch2/blob/master/docs/slow-compiles.md

--- a/test/pixel_types_test.cpp
+++ b/test/pixel_types_test.cpp
@@ -1,6 +1,6 @@
 
 // catch
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 // std
 #include <utility>

--- a/test/point_test.cpp
+++ b/test/point_test.cpp
@@ -1,6 +1,6 @@
 
 // catch
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 // std
 #include <sstream>

--- a/test/range_test.cpp
+++ b/test/range_test.cpp
@@ -1,6 +1,6 @@
 
 // catch
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 // to be tested
 #include "core/range.h"

--- a/test/rect_test.cpp
+++ b/test/rect_test.cpp
@@ -1,6 +1,6 @@
 
 // catch
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 // std
 #include <sstream>

--- a/test/size_test.cpp
+++ b/test/size_test.cpp
@@ -1,6 +1,6 @@
 
 // catch
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 // std
 #include <stdexcept>

--- a/test/util_test.cpp
+++ b/test/util_test.cpp
@@ -1,6 +1,6 @@
 
 // catch
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 // std
 #include <cstdint>


### PR DESCRIPTION
Hi, The file `catch.hpp` has been moved to `catch2/catch.hpp` since catch 2.3.0 (almost one year old). As you are adding this to Travis I thought this quick fix might be needed :)