### PR TITLE
Add Linux/Clang, Windows/MSVC & OSX/Clang to Travis CI Build Matrix

### DIFF
--- a/.ci/osx-install-gcc.sh
+++ b/.ci/osx-install-gcc.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# exit on non-zero return, echo all lines
+set -ev
+
+if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+  # Update command line tool to avoid an error:
+  # "_stdio.h: No such file or directory", when building samtools.
+  softwareupdate --list
+  softwareupdate --install "Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.1"
+  brew install gcc@7
+fi

--- a/.ci/setup-vcpkg.sh
+++ b/.ci/setup-vcpkg.sh
@@ -9,7 +9,7 @@ required="catch2 tiff spdlog benchmark asyncplusplus cxxopts"
 cd ./external/vcpkg
 
 if [ "${TRAVIS_OS_NAME}" = "linux" ] || [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-  ./bootstrap-vcpkg.sh
+  env CC=gcc-7 CXX=g++-7 ./bootstrap-vcpkg.sh
 else
   cmd "/C bootstrap-vcpkg.bat"
 fi

--- a/.ci/setup-vcpkg.sh
+++ b/.ci/setup-vcpkg.sh
@@ -6,6 +6,12 @@ set -ev
 # setup vcpkg and install required packages
 required="catch2 tiff spdlog benchmark asyncplusplus cxxopts"
 
-pushd ./external/vcpkg
-./bootstrap-vcpkg.sh
+cd ./external/vcpkg
+
+if [ "${TRAVIS_OS_NAME}" = "linux" ] || [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+  ./bootstrap-vcpkg.sh
+else
+  cmd "/C bootstrap-vcpkg.bat"
+fi
+
 ./vcpkg install ${required}

--- a/.ci/windows-upgrade-to-vs2019.sh
+++ b/.ci/windows-upgrade-to-vs2019.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/bash
+
+if [ "${TRAVIS_OS_NAME}" = "windows" ]; then
+  choco install visualstudio2019buildtools --package-parameters \
+    "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK"
+  choco upgrade cmake
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,18 @@ matrix:
       dist: bionic
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
-    
+    - os: windows
+      env:
+        - VCPKG_DEFAULT_TRIPLET="x64-windows"
+        - CMAKE_BUILD_EXTRA_ARGS="--config Debug"
+        - CTEST_EXTRA_ARGS="-C Debug"
 
 before_install:
     - eval "${MATRIX_EVAL}"
 
 install:
-- ./.ci/setup-vcpkg.sh
+- sh ./.ci/windows-upgrade-to-vs2019.sh
+- sh ./.ci/setup-vcpkg.sh
 
 cache:
   directories:
@@ -32,6 +37,6 @@ script:
 - mkdir build
 - cd build
 - cmake -DCMAKE_TOOLCHAIN_FILE=../external/vcpkg/scripts/buildsystems/vcpkg.cmake ..
-- make
-- ctest
+- cmake --build . ${CMAKE_BUILD_EXTRA_ARGS}
+- ctest ${CTEST_EXTRA_ARGS}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ matrix:
             - g++-7
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+    - os: linux
+      dist: bionic
+      env:
+        - MATRIX_EVAL="CC=clang && CXX=clang++"
+    
 
 before_install:
     - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
       dist: bionic
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
+    - os: osx
+      osx_image: xcode10.2
+      env:
+        - MATRIX_EVAL="CC=clang && CXX=clang++"
     - os: windows
       env:
         - VCPKG_DEFAULT_TRIPLET="x64-windows"
@@ -26,6 +30,7 @@ before_install:
     - eval "${MATRIX_EVAL}"
 
 install:
+- sh ./.ci/osx-install-gcc.sh
 - sh ./.ci/windows-upgrade-to-vs2019.sh
 - sh ./.ci/setup-vcpkg.sh
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,12 @@ set(openpiv-c++_VERSION_PATCH 0)
 
 enable_testing()
 
+if(WIN32)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/out)
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/out)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif(WIN32)
+
 add_subdirectory(lib)
 add_subdirectory(test)
 add_subdirectory(examples)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -33,6 +33,7 @@ set(LIBS ${LIBS} Threads::Threads)
 set(LIBNAME openpivcore)
 add_compile_options(-ffast-math)
 add_library(${LIBNAME} SHARED ${SOURCE})
+target_compile_definitions(${LIBNAME} PUBLIC _USE_MATH_DEFINES)
 target_link_libraries(${LIBNAME} ${LIBS})
 
 # install

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -24,7 +24,7 @@ if(TIFF_FOUND)
     ${TIFF_LIBRARIES})
 
   include_directories(${TIFF_EXTERNAL_LIBRARY_CXX})
-  include_directories(TIFF_INCLUDE_DIR)
+  include_directories(${TIFF_INCLUDE_DIR})
 endif()
 
 find_package(Threads REQUIRED)

--- a/lib/include/openpiv/core/util.h
+++ b/lib/include/openpiv/core/util.h
@@ -17,6 +17,14 @@
 // openpiv
 #include "core/exception_builder.h"
 
+// define POSIX-style endianness constants for MSVC
+// (to be replaced w/ C++20 std::endian)
+#ifdef _MSC_VER
+  #define __ORDER_LITTLE_ENDIAN__ 1
+  #define __ORDER_BIG_ENDIAN__ 0
+  #define __BYTE_ORDER__ 1
+#endif
+
 namespace openpiv::core {
 
 /// strongly typed memcpy with ability to stride over data

--- a/test/image_expression_test.cpp
+++ b/test/image_expression_test.cpp
@@ -160,6 +160,6 @@ TEST_CASE("image_expression_test - scale_test")
     REQUIRE(!!writer);
     REQUIRE(writer->name() == std::string("image/x-portable-anymap"));
 
-    std::fstream os( "A_00001_a.pgm", std::ios_base::trunc | std::ios_base::out );
+    std::fstream os( "A_00001_a.pgm", std::ios_base::trunc | std::ios_base::out | std::ios_base::binary );
     writer->save( os, im );
 }

--- a/test/image_loader_test.cpp
+++ b/test/image_loader_test.cpp
@@ -63,7 +63,7 @@ TEST_CASE("image_loader_test - pnm_loader_save_p5")
     REQUIRE(!!writer);
     REQUIRE(writer->name() == std::string("image/x-portable-anymap") );
 
-    std::fstream os( "test-mono.pgm", std::ios_base::trunc | std::ios_base::out );
+    std::fstream os( "test-mono.pgm", std::ios_base::trunc | std::ios_base::out | std::ios_base::binary );
     writer->save( os, im );
 }
 
@@ -83,6 +83,6 @@ TEST_CASE("image_loader_test - pnm_loader_save_p6")
     REQUIRE(!!writer);
     REQUIRE(writer->name() == std::string("image/x-portable-anymap") );
 
-    std::fstream os( "test-rgb.ppm", std::ios_base::trunc | std::ios_base::out );
+    std::fstream os( "test-rgb.ppm", std::ios_base::trunc | std::ios_base::out | std::ios_base::binary );
     writer->save( os, im );
 }

--- a/test/image_test.cpp
+++ b/test/image_test.cpp
@@ -190,7 +190,7 @@ TEST_CASE("image_test - scale_test")
     REQUIRE(!!writer);
     REQUIRE(writer->name() == "image/x-portable-anymap");
 
-    std::fstream os( "A_00001_a.pgm", std::ios_base::trunc | std::ios_base::out );
+    std::fstream os( "A_00001_a.pgm", std::ios_base::trunc | std::ios_base::out | std::ios_base::binary );
     writer->save( os, im );
 }
 

--- a/test/image_utils_test.cpp
+++ b/test/image_utils_test.cpp
@@ -64,7 +64,7 @@ TEST_CASE("image_test - pnm_load_save_test")
     // write data
     std::shared_ptr<image_loader> writer{ image_loader::find_loader("image/x-portable-anymap") };
     {
-        std::fstream os( "A_00001_a.pgm", std::ios_base::trunc | std::ios_base::out );
+        std::fstream os( "A_00001_a.pgm", std::ios_base::trunc | std::ios_base::out | std::ios_base::binary );
         writer->save( os, im );
     }
 
@@ -79,7 +79,7 @@ TEST_CASE("image_test - pnm_load_save_test")
     loader->load( is, reloaded );
 
     {
-        std::ofstream os( "reloaded.pgm", std::ios_base::trunc | std::ios_base::out );
+        std::ofstream os( "reloaded.pgm", std::ios_base::trunc | std::ios_base::out | std::ios_base::binary );
         writer->save( os, reloaded );
     }
 
@@ -143,7 +143,7 @@ TEST_CASE("image_test - rgba_join_test")
     rgba16_image rgba = join_from_channels( r, g, b, a);
 
     std::shared_ptr<image_loader> writer{ image_loader::find_loader("image/x-portable-anymap") };
-    std::fstream os( "test-rgbjoin.ppm", std::ios_base::trunc | std::ios_base::out );
+    std::fstream os( "test-rgbjoin.ppm", std::ios_base::trunc | std::ios_base::out | std::ios_base::binary );
     writer->save( os, rgba );
 }
 


### PR DESCRIPTION
This adds the following platforms to Travis build matrix:

- Linux Ubuntu 18.04, Clang 7

- macOS 10.14, Clang 9

- Windows Server 1803, MSVC 19.21 (Visual Studio 2019)

I also had to modify some code and CMakeLists to make things work on windows.

It now compiles on all platforms and passes the tests, but in the case of windows it still throws some warnings which I'm not really sure how to fix them. The warnings can be seen on the log of windows build in Travis.